### PR TITLE
Update python version from 3.5 to 3.6

### DIFF
--- a/0_preparation.md
+++ b/0_preparation.md
@@ -7,7 +7,7 @@
 
 ## Pythonをインストール
 
-* Python 3.5.2をダウンロードしてインストールしてください
+* Python 3.6.1をダウンロードしてインストールしてください
 * https://www.python.org/downloads/
 * Windowsの人はPATHの設定を行ってください。下記のページが参考になります
 

--- a/1_python_basics.md
+++ b/1_python_basics.md
@@ -3,7 +3,7 @@
 ## インストール
 
 https://www.python.org/downloads/ にインストーラがあるのでそれを使ってインストールします。
-現在(2015/11/15)の最新はPython3.5です。
+現在(2017/5/17)の最新はPython3.6.1です。
 
 Windows環境の方は環境変数を設定してください。
 この辺が参考になるかも。
@@ -15,8 +15,8 @@ http://www.pythonweb.jp/install/setup/index1.html
 
 ```python
 $ python
-Python 3.5.2 (v3.5.2:4def2a2901a5, Jun 26 2016, 10:47:25) 
-[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
+Python 3.6.1 (default, Apr  4 2017, 09:40:21)
+[GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)] on darwin
 Type "help", "copyright", "credits" or "license" for more information.
 >>>
 ```
@@ -414,7 +414,7 @@ import文を使うことで標準モジュールを使うことができます�
 - os 実行しているOSなどの環境の情報の取得や操作など
 
 他にもいっぱいあります。
-http://docs.python.jp/3.5/library/index.html
+http://docs.python.jp/3/library/index.html
 
 ### サードパーティパッケージを使う
 
@@ -471,7 +471,7 @@ requestsがアンインストールされました。
 venv環境を作成します。
 
 ```sh
-$ pyvenv-3.5 env
+$ python -m venv env
 ```
 
 venv環境に入ります。(activateスクリプトをsourceコマンドで読み込む)
@@ -518,7 +518,7 @@ ImportError: No module named 'requests'
 venv環境を作成します。
 
 ```
-c:\Temp>c:\Python35\python -m venv env
+c:\Temp>c:\Python36\python -m venv env
 ```
 
 venv環境に入ります。(activate.batを実行する)

--- a/1_python_basics.md
+++ b/1_python_basics.md
@@ -14,7 +14,7 @@ http://www.pythonweb.jp/install/setup/index1.html
 ### Pythonの実行
 
 ```python
-$ python
+$ python3.6
 Python 3.6.1 (default, Apr  4 2017, 09:40:21)
 [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)] on darwin
 Type "help", "copyright", "credits" or "license" for more information.
@@ -471,7 +471,7 @@ requestsがアンインストールされました。
 venv環境を作成します。
 
 ```sh
-$ python -m venv env
+$ python3.6 -m venv env
 ```
 
 venv環境に入ります。(activateスクリプトをsourceコマンドで読み込む)

--- a/2_scraping.md
+++ b/2_scraping.md
@@ -41,7 +41,7 @@ BeautifulSoup objectのよく使うmethod
 
 
 詳しくはこちらを参照してください。
-http://kondou.com/BS4/
+https://www.crummy.com/software/BeautifulSoup/bs4/doc/
 
 ## データの永続化
 
@@ -49,7 +49,7 @@ http://kondou.com/BS4/
 
 CSVはカンマで区切られた形式のファイルです。csvモジュールが使えます。
 csv モジュールのさらに詳しい内容についてはこちらを参照してください。
-http://docs.python.jp/3.4/library/csv.html
+http://docs.python.jp/3/library/csv.html
 
 #### 書き込み
 
@@ -92,7 +92,7 @@ JSON形式もよく使われる形式です。標準モジュールの `json` �
 - json.load() -> ファイル内のJSON文字列を読み込んでオブジェクトにする
 
 詳しい内容についてはこちらを参照してください。
-http://docs.python.jp/3.4/library/json.html
+http://docs.python.jp/3/library/json.html
 
 ## サンプル
 


### PR DESCRIPTION
ドキュメントで使用しているPythonのversionを3.5→3.6に上げました。
それに付随して、関連のリンクも最新版に対応しました。

ref: #4 , #5