### PR TITLE
Change a recommended editor from Atom to VS Code

### DIFF
--- a/0_preparation.md
+++ b/0_preparation.md
@@ -26,8 +26,11 @@
 
   * [Visual Studio Code - Code Editing. Redefined](https://code.visualstudio.com/ "Visual Studio Code - Code Editing. Redefined")
 
-* 他に以下のIDEもおすすめです
+* 他に以下のIDE,エディタもおすすめです
 
+  * [Atom](https://atom.io/ "Atom")
+    * メニューを日本語化したい人はこちらもあわせてどうぞ
+    * [Atomでパッケージをインストールする方法とメニューの日本語化 – nocorica](http://blog.nocorica.jp/2015/03/atom-package-install/ "Atomでパッケージをインストールする方法とメニューの日本語化 – nocorica")
   * [PyCharm](https://www.jetbrains.com/pycharm/download/ "PyCharm :: Download Latest Version of PyCharm")(Community版は無料です)
 
 ## connpass参加登録

--- a/0_preparation.md
+++ b/0_preparation.md
@@ -22,11 +22,9 @@
 
 * プログラムを書くためのエディタを準備してください
 * 普段使っているエディタがある人はそのエディタを使ってください。なお、utf-8で保存できる必要があります
-* 普段エディタを使っていない人は Atom というエディタがおすすめなので、インストールしておいてください
+* 普段エディタを使っていない人は Visual Studio Code(通称 VS Code) というエディタがおすすめなので、インストールしておいてください
 
-  * [Atom](https://atom.io/ "Atom")
-  * メニューを日本語化したい人はこちらもあわせてどうぞ
-  * [Atomでパッケージをインストールする方法とメニューの日本語化 – nocorica](http://blog.nocorica.jp/2015/03/atom-package-install/ "Atomでパッケージをインストールする方法とメニューの日本語化 – nocorica")
+  * [Visual Studio Code - Code Editing. Redefined](https://code.visualstudio.com/ "Visual Studio Code - Code Editing. Redefined")
 
 * 他に以下のIDEもおすすめです
 


### PR DESCRIPTION
このPRは #9 の出直しのうちの1つです。
内容はタイトル通りで、オススメするエディタをVS Codeに変更します。