### PR TITLE
Update from Python2 to Python3 for CSV

### DIFF
--- a/2_scraping.md
+++ b/2_scraping.md
@@ -55,19 +55,19 @@ http://docs.python.jp/3/library/csv.html
 
 ```py
 import csv
-with open('some.csv', 'wb') as f:
+with open('some.csv', 'w') as f:
     writer = csv.writer(f)
-    writer.writerows(someiterable)
+    writer.writerows(['1', '2', '3'])
 ```
 
 #### 読み取り
 
 ```py
 import csv
-with open('some.csv', 'rb') as f:
+with open('some.csv', 'r') as f:
     reader = csv.reader(f)
     for row in reader:
-        print row
+        print(row)
 ```
 
 ### JSON形式


### PR DESCRIPTION
- CSVモジュールの説明用コードがPython2のものだったので、Python3対応しました。
- 書き込み処理で `someiterable` とそのままでは実行できないものだったので、実行できる形式に対応しました。