### PR TITLE
公式インストーラーから入れたPythonでは sudo は不要なので説明からも消す

### DIFF
--- a/1_python_basics.md
+++ b/1_python_basics.md
@@ -421,7 +421,7 @@ Pythonユーザによっては独自に開発したパッケージをインタ�
 ここではHTTPライブラリをinstallします。
 
 ```sh
-$ sudo pip install requests
+$ pip install requests
 ```
 
 Pythonを起動してrequestsをimportします。
@@ -443,10 +443,8 @@ example.comにHTTPでGETリクエストを投げてみます。
 requestsが不要になった場合は`pip uninstall` でアンインストールできます。
 (y/n)で入力待ちになるのでyを入力しエンターキーを押下します。
 
-注意) 権限の問題でsudoが必要な場合が多いです。
-
 ```sh
-$ sudo pip uninstall requests
+$ pip uninstall requests
 〜省略〜
 Proceed (y/n)? y [ENTER]
   Successfully uninstalled requests-2.7.0
@@ -480,7 +478,6 @@ $ source env/bin/activate
 ```
 
 例としてrequestsをインストールします。
-※ venvで作成した環境はsudoが必要ありません。
 
 ```sh
 (env) $ pip install requests


### PR DESCRIPTION
## 概要 (2017-10-27 19:21 更新)

macOS において 2017-10-27 現在は公式インストーラーからインストールした Python 3.6.3 では sudo を使わずに pip install をすることができます。あまり詳細な説明をせずに不要な sudo の実行を推めるのは良いことでは無いので説明から削除します。

### 補足

ここで言う公式インストーラーとは以下のページから取得可能なインストーラーのことを言います。
[Download Python | Python.org](https://www.python.org/downloads/)
