### PR TITLE
refs #41 制御構文のリンク先修正

### DIFF
--- a/1_python_basics.md
+++ b/1_python_basics.md
@@ -322,7 +322,7 @@ def decide_amount(name, count, threshold=1000):
 decide_amount()では合計金額がthresholdより大きいか同じか未満かを判定してそれぞれ高い/普通/安いをprintしています。
 
 ここで登場した if の処理は以下のページでより詳しく見ることができます。
-https://goo.gl/xMMtvY
+https://goo.gl/V2Et3W
 
 #### for in
 
@@ -388,7 +388,7 @@ def calc_fruit_amount(name, count):
 ```
 
 ここで登場した try の処理は以下のページでより詳しく見ることができます。  
-https://goo.gl/Mg2LCB
+https://goo.gl/39uWD7
 
 #### fizzbuzz
 


### PR DESCRIPTION
## 目的

pythontutorのパーマリンクでcalc_fruit_amount関数が定義されておらず処理に失敗する箇所があるので修正する

## 内容
制御構文の説明の以下に挙げるリンクを、定義し直したパーマリンクに修正する


- if: https://goo.gl/xMMtvY
- try: https://goo.gl/Mg2LCB

