### PR TITLE
Update for pynyumon8

### DIFF
--- a/2_scraping.md
+++ b/2_scraping.md
@@ -68,7 +68,7 @@ https://www.crummy.com/software/BeautifulSoup/bs4/doc/
 
 CSVはカンマで区切られた形式のファイルです。csvモジュールが使えます。
 csv モジュールのさらに詳しい内容についてはこちらを参照してください。
-http://docs.python.jp/3/library/csv.html
+http://docs.python.org/ja/3.6/library/csv.html
 
 #### 書き込み
 
@@ -111,7 +111,7 @@ JSON形式もよく使われる形式です。標準モジュールの `json` �
 - json.load() -> ファイル内のJSON文字列を読み込んでオブジェクトにする
 
 詳しい内容についてはこちらを参照してください。
-http://docs.python.jp/3/library/json.html
+http://docs.python.org/ja/3.6/library/json.html
 
 ## サンプル
 

--- a/2_scraping.md
+++ b/2_scraping.md
@@ -115,9 +115,9 @@ http://docs.python.jp/3/library/json.html
 
 ## サンプル
 
-### PyNyumon #7 の講師・メンターを取得する
+### PyNyumon #8 の講師・メンターを取得する
 
-[Python入門者向けハンズオン #7 - connpass](https://python-nyumon.connpass.com/event/83667/) の講師・メンター一覧を取得するものです。
+[Python入門者向けハンズオン #8 - connpass](https://python-nyumon.connpass.com/event/100817/) の講師・メンター一覧を取得するものです。
 
 ```python
 import requests
@@ -126,8 +126,8 @@ from bs4 import BeautifulSoup
 
 def main():
 
-    # connpass の PyNumon#7 のイベント参加者・申込者一覧のURL
-    url = 'https://python-nyumon.connpass.com/event/83667/participation'
+    # connpass の PyNumon#8 のイベント参加者・申込者一覧のURL
+    url = 'https://python-nyumon.connpass.com/event/100817/participation'
 
     # requests で参加者一覧の情報と取得する
     response = requests.get(url)
@@ -165,23 +165,16 @@ if __name__ == '__main__':
     main()
 ```
 
-上記の内容を `pynyumon7-mentors.py` といった適当な名前のファイルに保存して実行すると利用できます。  
+上記の内容を `pynyumon8-mentors.py` といった適当な名前のファイルに保存して実行すると利用できます。
 
 実行すると以下のとおりになります。
 
 ```console
-$ python pynyumon7-mentors.py
-OMEGA
-Kei Iwasaki
-shunsuke_takeno
-Takanori Suzuki
-tokibito
-mocamocaland
+$ python pynyumon8-mentors.py
 nikkie
-Noriyuki
 kashew_nuts
-株式会社タイセイ　アウトソーシング事業部 (伊藤/榊/武内)
-Ryo KAJI
-
+shi-ma
+Kei Iwasaki
+mocamocaland
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ Python入門者向けハンズオンテキスト
   (講師: [@laugh_k](https://twitter.com/laugh_k))
 * 2018年5月12日(土) [Python入門者向けハンズオン #7](https://python-nyumon.connpass.com/event/83667/)
   (講師: [@laugh_k](https://twitter.com/laugh_k))
+* 2018年12月1日(土) [Python入門者向けハンズオン #8](https://python-nyumon.connpass.com/event/100817/)
+  (講師: [@laugh_k](https://twitter.com/laugh_k))


### PR DESCRIPTION
[Python入門者向けハンズオン #8 - connpass](https://python-nyumon.connpass.com/event/100817/) 向けに情報を更新する

- pynyumon#8の開催実績の記述を追加
- connpassのリンクを pynyumon#7 から pynyumon#8 に変更
- Pythonドキュメントのリンクを最新化